### PR TITLE
update with new ppl scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The winning entry will receive $20,000 in Mechanical Turk funding -- in order to
 | Model                | Creator  | PPL           | Hits@1  |   F1   |
 | -------------        | ---      | :------------- | :-----  |  :----- |
 |  [Seq2Seq + Attention](https://github.com/facebookresearch/ParlAI/tree/master/projects/convai2/baselines/seq2seq)  | ParlAI team          | 42.57&#x1F34E;        | -       | 16.18&#x1F34E; |
-|  Language Model       | ParlAI team          | 47.48         | -       |  14.86 |
+|  Language Model       | ParlAI team          | 85.44         | -       |  14.86 |
 |  [KV Profile Memory](https://github.com/facebookresearch/ParlAI/tree/master/projects/convai2/baselines/kvmemnn)    | ParlAI team          | -             | 55.1&#x1F34E;    |  13.3  |
 
 &#x1F34E; denotes the current best performing model for each metric on the hidden test set.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The winning entry will receive $20,000 in Mechanical Turk funding -- in order to
 
 | Model                | Creator  | PPL           | Hits@1  |   F1   |
 | -------------        | ---      | :------------- | :-----  |  :----- |
-|  [Seq2Seq + Attention](https://github.com/facebookresearch/ParlAI/tree/master/projects/convai2/baselines/seq2seq)  | ParlAI team          | 30.93&#x1F34E;        | -       | 16.18&#x1F34E; |
+|  [Seq2Seq + Attention](https://github.com/facebookresearch/ParlAI/tree/master/projects/convai2/baselines/seq2seq)  | ParlAI team          | 42.57&#x1F34E;        | -       | 16.18&#x1F34E; |
 |  Language Model       | ParlAI team          | 47.48         | -       |  14.86 |
 |  [KV Profile Memory](https://github.com/facebookresearch/ParlAI/tree/master/projects/convai2/baselines/kvmemnn)    | ParlAI team          | -             | 55.1&#x1F34E;    |  13.3  |
 


### PR DESCRIPTION
- predicting an UNK gives you loss of math.log(1e-8)
- END tokens are no longer evaluated